### PR TITLE
Use metric:declare to tolerate elli restart

### DIFF
--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -46,8 +46,8 @@ handle_event(request_complete, [Req,StatusCode,_Hs,_B,Timings], _Config) ->
   prometheus_histogram:observe(?DURATION, Labels, duration(Timings)),
   ok;
 handle_event(elli_startup, _Args, _Config) ->
-  prometheus_counter:new(metric(?TOTAL, ?LABELS, "request count")),
-  prometheus_histogram:new(metric(?DURATION, ?LABELS, "execution time")),
+  prometheus_counter:declare(metric(?TOTAL, ?LABELS, "request count")),
+  prometheus_histogram:declare(metric(?DURATION, ?LABELS, "execution time")),
   ok;
 handle_event(_Event, _Args, _Config) ->
   ok.


### PR DESCRIPTION
Hey!

So when supervisor restarts elli `elli_startup` event is generated and `prometheus_<metric>:new/1,2` would be called now. The 'problem' is `prometheus_<metric>:new/1,2` really expects non-existent metric! For restarts-friendly use-cases there is `prometheus_<metric>:declare/1,2` which is basically the same as `prometheus_<metric>:new/1,2` except it is ok if metric already exists.
