### PR TITLE
Small rewrite

### DIFF
--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -26,6 +26,8 @@
 %% TODO: Describe format.
 %% TODO: Add links to Prometheus and Prometheus.erl docs.
 %% TODO: Make path configurable.
+%% TODO: Make export format configurable.
+%% TODO: Make duration buckets configurable.
 handle(Req, _Config) ->
   case {elli_request:method(Req),elli_request:raw_path(Req)} of
     {'GET',<<"/metrics">>} -> {ok,[],prometheus_text_format:format()};

--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -46,8 +46,8 @@ handle_event(request_complete, [Req,StatusCode,_Hs,_B,Timings], _Config) ->
   prometheus_histogram:observe(?DURATION, Labels, duration(Timings)),
   ok;
 handle_event(elli_startup, _Args, _Config) ->
-  prometheus_counter:new(metric(?TOTAL, ?LABELS, "request count")),
-  prometheus_histogram:new(metric(?DURATION, ?LABELS, "execution time")),
+  prometheus_counter:declare(metric(?TOTAL, ?LABELS, "request count")),
+  prometheus_histogram:declare(metric(?DURATION, ?LABELS, "execution time")),
   ok;
 handle_event(_Event, _Args, _Config) ->
   ok.

--- a/src/elli_prometheus_config.erl
+++ b/src/elli_prometheus_config.erl
@@ -1,0 +1,32 @@
+-module(elli_prometheus_config).
+
+-export([path/0,
+         format/0,
+         duration_buckets/0]).
+
+-define(DEFAULT_PATH, <<"/metrics">>).
+-define(DEFAULT_FORMAT, prometheus_text_format).
+-define(DEFAULT_DURATION_BUCKETS, [10, 100, 1000, 10000, 100000, 300000, 500000,
+                                   750000, 1000000, 1500000, 2000000, 3000000]).
+
+-define(DEFAULT_CONFIG, [{path, ?DEFAULT_PATH},
+                         {format, ?DEFAULT_FORMAT},
+                         {duration_buckets, ?DEFAULT_DURATION_BUCKETS}]).
+
+config() ->
+  application:get_env(prometheus, elli_exporter, ?DEFAULT_CONFIG).
+
+path() ->
+  Config = config(),
+  proplists:get_value(path, Config, ?DEFAULT_PATH).
+
+format() ->
+  Config = config(),
+  proplists:get_value(format, Config, ?DEFAULT_FORMAT).
+
+duration_buckets() ->
+  Config = config(),
+  proplists:get_value(duration_buckets, Config, ?DEFAULT_DURATION_BUCKETS).
+  
+
+


### PR DESCRIPTION
Hey!

This PR incorporates #1 and #2. It also allows configurable scrape path, format and duration buckets.
I implemented configuration based on prometheus application environment. It's probably not idiomatic from elli's point of view so please do let me know if this is not acceptable.

I would also like to note that `status_code` label can lead to 'overflow'. While set of values of this label is definitely finite it's still can be large. Prometheus treats each label set as separate time series.
Likely there is also usability issue - imagine you want to graph all successful replies then you have to use [regex matches](https://prometheus.io/docs/querying/basics/#instant-vector-selectors). So maybe introduce `status_class` label and make `status_code` optional?
