### PR TITLE
Make labels set configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dependencies
 
 `elli_prometheus` requires [Elli][] and [Prometheus][], but neither are included
 in this project. It has been tested and is known to work with `{elli, "1.0.5"}`
-and `{prometheus, "1.6.0"}`.
+and `{prometheus, "1.7.0"}`.
 
 [Elli]: https://github.com/knutin/elli
 [Prometheus]: https://github.com/deadtrickster/prometheus.erl

--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -12,7 +12,6 @@
 -export([handle/2,handle_event/3]).
 
 %% Macros.
--define(LABELS,   [method,handler,status_code]).
 -define(TOTAL,    http_requests_total).
 -define(DURATION, http_request_duration_microseconds).
 
@@ -36,19 +35,15 @@ handle(Req, _Config) ->
 %% `http_requests_total' and {@link prometheus_histogram:observe/3. observe}
 %% `http_request_duration_microseconds'. Ignore all other events.
 handle_event(request_complete, [Req,StatusCode,_Hs,_B,Timings], _Config) ->
-  Method      = elli_request:method(Req),
-  Handler     = case elli_request:path(Req) of
-                  [H|_] -> H;
-                  []    -> ""
-                end,
-  Labels      = [Method,Handler,StatusCode],
+  Labels = labels(Req, StatusCode),
   prometheus_counter:inc(?TOTAL, Labels),
   prometheus_histogram:observe(?DURATION, Labels, duration(Timings)),
   ok;
 handle_event(elli_startup, _Args, _Config) ->
-  prometheus_counter:declare(metric(?TOTAL, ?LABELS, "request count")),
+  Labels          = elli_prometheus_config:labels(),
   DurationBuckets = elli_prometheus_config:duration_buckets(),
-  prometheus_histogram:declare(metric(?DURATION, ?LABELS, DurationBuckets, "execution time")),
+  prometheus_counter:declare(metric(?TOTAL, Labels, "request count")),
+  prometheus_histogram:declare(metric(?DURATION, Labels, DurationBuckets, "execution time")),
   ok;
 handle_event(_Event, _Args, _Config) ->
   ok.
@@ -71,3 +66,19 @@ metric(Name, Labels, Desc) ->
 
 metric(Name, Labels, Buckets, Desc) ->
   [{name,Name},{labels,Labels},{help,"HTTP request "++Desc}, {buckets,Buckets}].
+
+labels(Req, StatusCode) ->
+  Labels = elli_prometheus_config:labels(),
+  [label(Label, Req, StatusCode) || Label <- Labels].
+
+label(method, Req, _) ->
+  elli_request:method(Req);
+label(handler, Req, _) ->
+  case elli_request:path(Req) of
+    [H|_] -> H;
+    []    -> ""
+  end;
+label(status_code, _, StatusCode) ->
+  StatusCode;
+label(status_class, _, StatusCode) ->
+  prometheus_http:status_class(StatusCode).

--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -70,4 +70,4 @@ metric(Name, Labels, Desc) ->
   metric(Name, Labels, [], Desc).
 
 metric(Name, Labels, Buckets, Desc) ->
-  [{name,Name},{labels,Labels},{help,"HTTP request "++Desc}, {buckets, Buckets}].
+  [{name,Name},{labels,Labels},{help,"HTTP request "++Desc}, {buckets,Buckets}].

--- a/src/elli_prometheus_config.erl
+++ b/src/elli_prometheus_config.erl
@@ -2,16 +2,19 @@
 
 -export([path/0,
          format/0,
-         duration_buckets/0]).
+         duration_buckets/0,
+         labels/0]).
 
 -define(DEFAULT_PATH, <<"/metrics">>).
 -define(DEFAULT_FORMAT, prometheus_text_format).
 -define(DEFAULT_DURATION_BUCKETS, [10,100,1000,10000,100000,300000,500000,
                                    750000,1000000,1500000,2000000,3000000]).
+-define(DEFAULT_LABELS, [method,handler,status_class]).
 
 -define(DEFAULT_CONFIG, [{path,?DEFAULT_PATH},
                          {format,?DEFAULT_FORMAT},
-                         {duration_buckets,?DEFAULT_DURATION_BUCKETS}]).
+                         {duration_buckets,?DEFAULT_DURATION_BUCKETS},
+                         {labels,?DEFAULT_LABELS}]).
 
 config() ->
   application:get_env(prometheus, elli_exporter, ?DEFAULT_CONFIG).
@@ -27,3 +30,7 @@ format() ->
 duration_buckets() ->
   Config = config(),
   proplists:get_value(duration_buckets, Config, ?DEFAULT_DURATION_BUCKETS).
+
+labels() ->
+  Config = config(),
+  proplists:get_value(labels, Config, ?DEFAULT_LABELS).

--- a/src/elli_prometheus_config.erl
+++ b/src/elli_prometheus_config.erl
@@ -6,12 +6,12 @@
 
 -define(DEFAULT_PATH, <<"/metrics">>).
 -define(DEFAULT_FORMAT, prometheus_text_format).
--define(DEFAULT_DURATION_BUCKETS, [10, 100, 1000, 10000, 100000, 300000, 500000,
-                                   750000, 1000000, 1500000, 2000000, 3000000]).
+-define(DEFAULT_DURATION_BUCKETS, [10,100,1000,10000,100000,300000,500000,
+                                   750000,1000000,1500000,2000000,3000000]).
 
--define(DEFAULT_CONFIG, [{path, ?DEFAULT_PATH},
-                         {format, ?DEFAULT_FORMAT},
-                         {duration_buckets, ?DEFAULT_DURATION_BUCKETS}]).
+-define(DEFAULT_CONFIG, [{path,?DEFAULT_PATH},
+                         {format,?DEFAULT_FORMAT},
+                         {duration_buckets,?DEFAULT_DURATION_BUCKETS}]).
 
 config() ->
   application:get_env(prometheus, elli_exporter, ?DEFAULT_CONFIG).
@@ -27,6 +27,3 @@ format() ->
 duration_buckets() ->
   Config = config(),
   proplists:get_value(duration_buckets, Config, ?DEFAULT_DURATION_BUCKETS).
-  
-
-


### PR DESCRIPTION
Also introduce `status_class` label:

excerpt /metrics:

```
http_request_duration_microseconds_bucket{method="GET",handler="",status_class="client-error",le="10"} 3
```
