### PR TITLE
Update to the latest Prometheus.erl & Elli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+language: erlang
+install: 'true'
+before_script:
+- wget https://s3.amazonaws.com/rebar3/rebar3
+- chmod +x rebar3
+env: PATH=$PATH:.
+cache:
+  directories:
+  - $HOME/.cache/rebar3/
+otp_release:
+- 19.0
+- 18.0
+script: "./rebar3 eunit"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 elli_prometheus
 =====
+[![Build Status](https://travis-ci.org/elli-lib/elli_prometheus.svg?branch=master)](https://travis-ci.org/elli-lib/elli_prometheus)
 
 [Elli][] middleware for collecting stats via [Prometheus][].
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,61 @@ elli_prometheus
 
 [Elli][] middleware for collecting stats via [Prometheus][].
 
+Metrics
+-----
+
+How Elli represents timings:
+
+```
+request_start
+    headers_start
+    ...headers receiving &  parsing...
+    headers_end
+
+    body_start
+    ...body receiving & parsing...
+    body_end
+
+    user_start
+    ...callback code...
+    user_end
+
+   send_start
+   ...sending reply....
+   send_end
+request_end
+```
+
+How Elli represents sizes:
+
+Each request has `resp_headers` key and, depending on
+response type, `resp_body` or `file` or `chunks` key.
+
+- `resp_header` is always present and denotes response headers wire size;
+- `resp_body` set for regular responses;
+- `file` set for file responses;
+- `chunks` set for chunked responses, wire size too.
+
+Elli_prometheus exportes the following metrics:
+
+- `http_requests_total`, counter. Total count of requests;
+- `http_request_duration_microseconds`, histogram. The difference between
+   `request_end` and `request_start`;
+- `http_request_headers_microseconds`, histogram. The difference between
+  `headers_end` and `headers_start`;
+- `http_request_body_microseconds`, histogram. The difference between
+  `body_end` and `body_start`;
+- `http_request_user_microseconds`, histogram. The difference between
+  `user_end` and `user_start`;
+- `http_request_send_microseconds`, histogram. The difference between
+  `send_end` and `send_start`;
+
+- `http_response_size_bytes`, summary. Total size of the response, includes
+  headers, body|file|chuncks;
+- `http_response_headers_size_bytes`, summary. Size of the response headers;
+- `http_response_body_size`, summary.
+  Size of the response body.
+
 Dependencies
 -----
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ For failed requests:
   Reasons:
   - `too_many_headers`;
   - `body_size`.
-- `http_client_closed_errors_total{request_part}` - Total count of `client_closed` errors.
+- `http_client_closed_total{request_part}` - Total count of `client_closed` errors.
    Parts:
    - `receiving_headers`;
    - `receiving_body`;
    - `before_response`.
-- `http_client_timeout_errors_total{request_part}` Total count of `client_timeout` errors.
+- `http_client_timeout_total{request_part}` Total count of `client_timeout` errors.
   Parts:
    - `receiving_headers`;
    - `receiving_body`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ response type, `resp_body` or `file` or `chunks` key.
 - `file` set for file responses;
 - `chunks` set for chunked responses, wire size too.
 
-Elli_prometheus exportes the following metrics:
+Elli_prometheus exports the following metrics:
 
 - `http_requests_total`, counter. Total count of requests;
 - `http_request_duration_microseconds`, histogram. The difference between
@@ -57,7 +57,33 @@ Elli_prometheus exportes the following metrics:
   headers, body|file|chuncks;
 - `http_response_headers_size_bytes`, summary. Size of the response headers;
 - `http_response_body_size`, summary.
-  Size of the response body.
+  Size of the response body;
+
+For failed requests:
+- `http_requests_failed_total{reason}`, Total count of failed requests. Reasons:
+  - `request_closed` - the client closes the connection when Elli is waiting for
+  the next request;
+  - `request_timeout` - the client times out when Elli is waiting for the request;
+  - `request_parse_error` - the request is invalid and cannot be parsed or it
+  contains a path Elli cannot parse or doesn't support;
+  - `client_closed` - the client closes the connection or socket closed
+  unexpectedly;
+  - `client_timeout` - data can't be received within a timeout;
+  - `bad_request` - Elli detects a request isn't well formatted or doesn't conform
+  to the configured limits.
+- `http_bad_requests_total{reason}` - Total count of `bad_request` errors.
+  Reasons:
+  - `too_many_headers`;
+  - `body_size`.
+- `http_client_closed_errors_total{request_part}` - Total count of `client_closed` errors.
+   Parts:
+   - `receiving_headers`;
+   - `receiving_body`;
+   - `before_response`.
+- `http_client_timeout_errors_total{request_part}` Total count of `client_timeout` errors.
+  Parts:
+   - `receiving_headers`;
+   - `receiving_body`.
 
 Dependencies
 -----

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ For failed requests:
   Parts:
    - `receiving_headers`;
    - `receiving_body`.
+   
+Exporter metrics:
+
+Labels: `registry`, `content_type`.
+
+* `telemetry_scrape_duration_seconds`<br />
+Type: summary.<br />
+Scrape duration.
+
+* `telemetry_scrape_size_bytes`<br />
+Type: summary.<br />
+Scrape size, uncompressed.
 
 Dependencies
 -----

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,9 @@
 {profiles, [
-  {test, [{deps, [{elli, "1.0.5"}, {prometheus, "1.7.0"}]}]},
-  {docs, [{deps, [{elli, "1.0.5"}, {prometheus, "1.7.0"}, {edown, "0.8.1"}]}]}
+  {test, [{deps, [{elli, {git, "https://github.com/elli-lib/elli.git", {branch, "develop"}}},
+                  {prometheus, "3.0.0-rc1"}]}]},
+  {docs, [{deps, [{elli, {git, "https://github.com/elli-lib/elli.git", {branch, "develop"}}},
+                  {prometheus, "3.0.0-rc1"},
+                  {edown, "0.8.1"}]}]}
 ]}.
 
 {edoc_opts, [

--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -1,10 +1,12 @@
 %% @doc Elli middleware for collecting stats via Prometheus.
 %% @author Eric Bailey
+%% @author Ilya Khaprov
 %% @version 0.0.1
 %% @reference <a href="https://prometheus.io">Prometheus</a>
 %% @copyright 2016 Eric Bailey
 -module(elli_prometheus).
 -author("Eric Bailey").
+-author("Ilya Khaprov").
 
 -behaviour(elli_handler).
 

--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -44,7 +44,7 @@ handle(Req, _Config) ->
 %% `http_request_duration_microseconds'. Ignore all other events.
 handle_event(request_complete, Args, Config) ->
   handle_full_response(request_complete, Args, Config);
-handle_event(chunks_complete, Args, Config) ->
+handle_event(chunk_complete, Args, Config) ->
   handle_full_response(chunk_complete, Args, Config);
 handle_event(elli_startup, _Args, _Config) ->
   Labels        = elli_prometheus_config:labels(),

--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -144,9 +144,15 @@ size(Sizes, response) ->
 size(Sizes, response_headers) ->
   proplists:get_value(resp_headers, Sizes);
 size(Sizes, response_body) ->
-  proplists:get_value(chunks, Sizes, false) orelse
-    proplists:get_value(file, Sizes, false) orelse
-    proplists:get_value(resp_body, Sizes).
+  case proplists:get_value(chunks, Sizes) of
+    undefined ->
+      case proplists:get_value(file, Sizes) of
+        undefined ->
+          proplists:get_value(resp_body, Sizes);
+        FileSize -> FileSize
+      end;
+    ChunksSize -> ChunksSize
+  end.
 
 metric(Name, Labels, Desc) -> metric(Name, Labels, [], Desc).
 

--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -12,8 +12,16 @@
 -export([handle/2,handle_event/3]).
 
 %% Macros.
--define(TOTAL,    http_requests_total).
--define(DURATION, http_request_duration_microseconds).
+-define(TOTAL, http_requests_total).
+-define(REQUEST_DURATION, http_request_duration_microseconds).
+-define(REQUEST_HEADERS_DURATION, http_request_headers_microseconds).
+-define(REQUEST_BODY_DURATION, http_request_body_microseconds).
+-define(REQUEST_USER_DURATION, http_request_user_microseconds).
+-define(REQUEST_SEND_DURATION, http_response_send_microseconds).
+
+-define(RESPONSE_SIZE, http_response_size_bytes).
+-define(RESPONSE_HEADERS_SIZE, http_response_headers_size_bytes).
+-define(RESPONSE_BODY_SIZE, http_response_body_size_bytes).
 
 %%%===================================================================
 %%% elli_handler callbacks
@@ -34,16 +42,16 @@ handle(Req, _Config) ->
 %% `request_complete', {@link prometheus_counter:inc/2. increment}
 %% `http_requests_total' and {@link prometheus_histogram:observe/3. observe}
 %% `http_request_duration_microseconds'. Ignore all other events.
-handle_event(request_complete, [Req,StatusCode,_Hs,_B,Timings], _Config) ->
-  Labels = labels(Req, StatusCode),
-  prometheus_counter:inc(?TOTAL, Labels),
-  prometheus_histogram:observe(?DURATION, Labels, duration(Timings)),
-  ok;
+handle_event(request_complete, Args, Config) ->
+  handle_full_response(request_complete, Args, Config);
+handle_event(chunks_complete, Args, Config) ->
+  handle_full_response(chunk_complete, Args, Config);
 handle_event(elli_startup, _Args, _Config) ->
   Labels        = elli_prometheus_config:labels(),
   Buckets       = elli_prometheus_config:duration_buckets(),
   RequestCount  = metric(?TOTAL, Labels, "request count"),
-  ExecutionTime = metric(?DURATION, Labels, Buckets, "execution time"),
+  ExecutionTime = metric(?REQUEST_DURATION, [response_type | Labels], Buckets,
+                         "execution time"),
   prometheus_counter:declare(RequestCount),
   prometheus_histogram:declare(ExecutionTime),
   ok;
@@ -53,14 +61,63 @@ handle_event(_Event, _Args, _Config) -> ok.
 %%% Private functions
 %%%===================================================================
 
+handle_full_response(Type, [Req,Code,_Hs,_B,{Timings, Sizes}], _Config) ->
+  Labels = labels(Req, Code),
+  TypedLabels = case Type of
+                  request_complete -> ["full" | Labels];
+                  chunk_complete -> ["chunks" | Labels];
+                  _ -> Labels
+                end,
+  prometheus_counter:inc(?TOTAL, Labels),
+
+  prometheus_histogram:observe(?REQUEST_DURATION, TypedLabels,
+                               duration(Timings, request)),
+  %% prometheus_histogram:observe(?REQUEST_HEADERS_DURATION, Labels,
+  %%                              duration(Timings, headers)),
+  %% prometheus_histogram:observe(?REQUEST_BODY_DURATION, Labels,
+  %%                              duration(Timings, body)),
+  %% prometheus_histogram:observe(?REQUEST_USER_DURATION, Labels,
+  %%                              duration(Timings, user)),
+  %% prometheus_histogram:observe(?REQUEST_SEND_DURATION, TypedLabels,
+  %%                              duration(Timings, send)),
+
+  %% prometheus_summary:observe(?RESPONSE_SIZE, Labels,
+  %%                            size(Sizes, response)),
+  %% prometheus_summary:observe(?RESPONSE_HEADERS_SIZE, Labels,
+  %%                            size(Sizes, response_headers)),
+  %% prometheus_summary:observe(?RESPONSE_BODY_SIZE, Labels,
+  %%                            size(Sizes, response_body)),
+  ok.
+
 format_metrics() ->
   Format = elli_prometheus_config:format(),
   {ok,[{<<"Content-Type">>,Format:content_type()}],Format:format()}.
 
-duration(Timings) ->
-  UserStart = proplists:get_value(user_start, Timings, {0,0,0}),
-  UserEnd   = proplists:get_value(user_end, Timings, {0,0,0}),
-  timer:now_diff(UserEnd, UserStart).
+duration(Timings, request) ->
+  duration(request_start, request_end, Timings);
+duration(Timings, headers) ->
+  duration(headers_start, headers_end, Timings);
+duration(Timings, body) ->
+  duration(body_start, body_end, Timings);
+duration(Timings, user) ->
+  duration(user_end, user_start, Timings);
+duration(Timings, send) ->
+  duration(send_end, send_start, Timings).
+
+duration(StartKey, EndKey, Timings) ->
+  Start = proplists:get_value(StartKey, Timings),
+  End   = proplists:get_value(EndKey, Timings),
+  End - Start.
+
+size(Sizes, response) ->
+  size(Sizes, response_headers) +
+    size(Sizes, response_body);
+size(Sizes, response_headers) ->
+  proplists:get_value(resp_headers, Sizes);
+size(Sizes, response_body) ->
+  proplists:get_value(chunks, Sizes, false) orelse
+    proplists:get_value(file, Sizes, false) orelse
+    proplists:get_value(resp_body, Sizes).
 
 metric(Name, Labels, Desc) -> metric(Name, Labels, [], Desc).
 
@@ -79,3 +136,46 @@ label(handler, Req, _) ->
   end;
 label(status_code,  _, StatusCode) -> StatusCode;
 label(status_class, _, StatusCode) -> prometheus_http:status_class(StatusCode).
+
+%% request_start
+%% headers_start
+%% headers_end
+%% body_start
+%% body_end
+%% user_start
+%% user_end
+%% send_start
+%% send_end
+%% request_end
+
+
+%% resp_headers
+%% resp_body
+%% file
+%% chunk
+
+%% exclusive event
+%% `request_closed' is sent if the client closes the connection when
+%% Elli is waiting for the next request on a keep alive connection.
+%%
+%% `request_timeout' is sent if the client times out when
+%% Elli is waiting for the request.
+%%
+%% `request_parse_error' fires if the request is invalid and cannot be parsed by
+%% [`erlang:decode_packet/3`][decode_packet/3] or it contains a path Elli cannot
+%% parse or does not support.
+%% `client_closed' can be sent from multiple parts of the request
+%% handling. It's sent when the client closes the connection or if for
+%% any reason the socket is closed unexpectedly. The `Where' atom
+%% tells you in which part of the request processing the closed socket
+%% was detected: `receiving_headers', `receiving_body' or `before_response'.
+%%
+%% `client_timeout' can as with `client_closed' be sent from multiple
+%% parts of the request handling. If Elli tries to receive data from
+%% the client socket and does not receive anything within a timeout,
+%% this event fires and the socket is closed.
+%%
+%% `bad_request' is sent when Elli detects a request is not well
+%% formatted or does not conform to the configured limits. Currently
+%% the `Reason' variable can be `{too_many_headers, Headers}'
+%% or `{body_size, ContentLength}'.

--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -43,11 +43,6 @@ handle(Req, _Config) ->
     _             -> ignore
   end.
 
-%% @doc On `elli_startup', register two metrics, a counter `http_requests_total'
-%% and a histogram `http_request_duration_microseconds'. Then, on
-%% `request_complete', {@link prometheus_counter:inc/2. increment}
-%% `http_requests_total' and {@link prometheus_histogram:observe/3. observe}
-%% `http_request_duration_microseconds'. Ignore all other events.
 handle_event(request_complete, Args, Config) ->
   handle_full_response(request_complete, Args, Config);
 handle_event(chunk_complete, Args, Config) ->

--- a/src/elli_prometheus.erl
+++ b/src/elli_prometheus.erl
@@ -17,7 +17,7 @@
 -define(REQUEST_HEADERS_DURATION, http_request_headers_microseconds).
 -define(REQUEST_BODY_DURATION, http_request_body_microseconds).
 -define(REQUEST_USER_DURATION, http_request_user_microseconds).
--define(REQUEST_SEND_DURATION, http_response_send_microseconds).
+-define(RESPONSE_SEND_DURATION, http_response_send_microseconds).
 
 -define(RESPONSE_SIZE, http_response_size_bytes).
 -define(RESPONSE_HEADERS_SIZE, http_response_headers_size_bytes).
@@ -50,10 +50,39 @@ handle_event(elli_startup, _Args, _Config) ->
   Labels        = elli_prometheus_config:labels(),
   Buckets       = elli_prometheus_config:duration_buckets(),
   RequestCount  = metric(?TOTAL, Labels, "request count"),
-  ExecutionTime = metric(?REQUEST_DURATION, [response_type | Labels], Buckets,
-                         "execution time"),
+  RequestDuration = metric(?REQUEST_DURATION, [response_type | Labels], Buckets,
+                           " latencies in microseconds"),
+  RequestHeadersDuration = metric(?REQUEST_HEADERS_DURATION,
+                                  Labels, Buckets,
+                                  "time spent receiving and parsing headers"),
+  RequestBodyDuration = metric(?REQUEST_BODY_DURATION,
+                               Labels, Buckets,
+                               "time spent receiving and parsing body"),
+  RequestUserDuration = metric(?REQUEST_USER_DURATION,
+                               Labels, Buckets,
+                               "time spent in user callback"),
+  ResponseSendDuration = metric(?RESPONSE_SEND_DURATION,
+                                [response_type | Labels], Buckets,
+                                "time spent sending reply"),
+  ResponseSize = metric(?RESPONSE_SIZE,
+                        [response_type | Labels],
+                        "total response size"),
+  ResponseHeaders = metric(?RESPONSE_HEADERS_SIZE,
+                           [response_type | Labels],
+                           "response headers size"),
+  ResponseBody = metric(?RESPONSE_BODY_SIZE,
+                        [response_type | Labels],
+                        "response body size"),
   prometheus_counter:declare(RequestCount),
-  prometheus_histogram:declare(ExecutionTime),
+  prometheus_histogram:declare(RequestDuration),
+  prometheus_histogram:declare(RequestHeadersDuration),
+  prometheus_histogram:declare(RequestBodyDuration),
+  prometheus_histogram:declare(RequestUserDuration),
+
+  prometheus_histogram:declare(ResponseSendDuration),
+  prometheus_summary:declare(ResponseSize),
+  prometheus_summary:declare(ResponseHeaders),
+  prometheus_summary:declare(ResponseBody),
   ok;
 handle_event(_Event, _Args, _Config) -> ok.
 
@@ -72,21 +101,21 @@ handle_full_response(Type, [Req,Code,_Hs,_B,{Timings, Sizes}], _Config) ->
 
   prometheus_histogram:observe(?REQUEST_DURATION, TypedLabels,
                                duration(Timings, request)),
-  %% prometheus_histogram:observe(?REQUEST_HEADERS_DURATION, Labels,
-  %%                              duration(Timings, headers)),
-  %% prometheus_histogram:observe(?REQUEST_BODY_DURATION, Labels,
-  %%                              duration(Timings, body)),
-  %% prometheus_histogram:observe(?REQUEST_USER_DURATION, Labels,
-  %%                              duration(Timings, user)),
-  %% prometheus_histogram:observe(?REQUEST_SEND_DURATION, TypedLabels,
-  %%                              duration(Timings, send)),
+  prometheus_histogram:observe(?REQUEST_HEADERS_DURATION, Labels,
+                               duration(Timings, headers)),
+  prometheus_histogram:observe(?REQUEST_BODY_DURATION, Labels,
+                               duration(Timings, body)),
+  prometheus_histogram:observe(?REQUEST_USER_DURATION, Labels,
+                               duration(Timings, user)),
+  prometheus_histogram:observe(?RESPONSE_SEND_DURATION, TypedLabels,
+                               duration(Timings, send)),
 
-  %% prometheus_summary:observe(?RESPONSE_SIZE, Labels,
-  %%                            size(Sizes, response)),
-  %% prometheus_summary:observe(?RESPONSE_HEADERS_SIZE, Labels,
-  %%                            size(Sizes, response_headers)),
-  %% prometheus_summary:observe(?RESPONSE_BODY_SIZE, Labels,
-  %%                            size(Sizes, response_body)),
+  prometheus_summary:observe(?RESPONSE_SIZE, TypedLabels,
+                             size(Sizes, response)),
+  prometheus_summary:observe(?RESPONSE_HEADERS_SIZE, TypedLabels,
+                             size(Sizes, response_headers)),
+  prometheus_summary:observe(?RESPONSE_BODY_SIZE, TypedLabels,
+                             size(Sizes, response_body)),
   ok.
 
 format_metrics() ->
@@ -100,9 +129,9 @@ duration(Timings, headers) ->
 duration(Timings, body) ->
   duration(body_start, body_end, Timings);
 duration(Timings, user) ->
-  duration(user_end, user_start, Timings);
+  duration(user_start, user_end, Timings);
 duration(Timings, send) ->
-  duration(send_end, send_start, Timings).
+  duration(send_start, send_end, Timings).
 
 duration(StartKey, EndKey, Timings) ->
   Start = proplists:get_value(StartKey, Timings),

--- a/test/elli_prometheus_test_callback.erl
+++ b/test/elli_prometheus_test_callback.erl
@@ -1,0 +1,15 @@
+-module(elli_prometheus_test_callback).
+-export([handle/2]).
+
+-include_lib("elli/include/elli.hrl").
+
+handle(Req, _Args) -> handle(Req#req.method, elli_request:path(Req), Req).
+
+handle('GET', [<<"hello">>, <<"world">>], _Req) ->
+    %% Reply with a normal response.
+    {ok, [], <<"Hello World!">>};
+
+handle('GET', [<<"hello">>], Req) ->
+    %% Fetch a GET argument from the URL.
+    Name = elli_request:get_arg(<<"name">>, Req, <<"undefined">>),
+    {ok, [], <<"Hello ", Name/binary>>}.

--- a/test/elli_prometheus_tests.erl
+++ b/test/elli_prometheus_tests.erl
@@ -4,12 +4,52 @@
 
 -define(README, "README.md").
 
+-define(EMPTY_SCRAPE_TEXT,
+        "# TYPE http_client_closed_total counter
+# HELP http_client_closed_total HTTP request \"client_closed\" errors count
+# TYPE http_requests_failed_total counter
+        # HELP http_requests_failed_total HTTP request failed total count.
+# TYPE http_client_timeout_total counter
+# HELP http_client_timeout_total HTTP request \"client_timeout\" errors count
+# TYPE http_bad_requests_total counter
+# HELP http_bad_requests_total HTTP request \"bad_request\" errors count
+# TYPE http_requests_total counter
+# HELP http_requests_total HTTP request request count
+# TYPE http_request_duration_microseconds histogram
+# HELP http_request_duration_microseconds HTTP request  latencies in microseconds
+# TYPE http_request_headers_microseconds histogram
+# HELP http_request_headers_microseconds HTTP request time spent receiving and parsing headers
+# TYPE http_request_user_microseconds histogram
+# HELP http_request_user_microseconds HTTP request time spent in user callback
+# TYPE http_response_send_microseconds histogram
+# HELP http_response_send_microseconds HTTP request time spent sending reply
+# TYPE http_request_body_microseconds histogram
+# HELP http_request_body_microseconds HTTP request time spent receiving and parsing body
+# TYPE http_response_body_size_bytes summary
+# HELP http_response_body_size_bytes HTTP request response body size
+# TYPE telemetry_scrape_duration_seconds summary
+# HELP telemetry_scrape_duration_seconds Scrape duration
+# TYPE http_response_size_bytes summary
+# HELP http_response_size_bytes HTTP request total response size
+# TYPE telemetry_scrape_size_bytes summary
+# HELP telemetry_scrape_size_bytes Scrape size, uncompressed
+# TYPE http_response_headers_size_bytes summary
+# HELP http_response_headers_size_bytes HTTP request response headers size
+
+").
+
+-define(EMPTY_SCRAPE_SIZE, 1762).
+
+normalize_text_scrape(Scrape) ->
+  lists:sort(lists:map(fun string:strip/1, string:tokens(Scrape, "\n"))).
+
 elli_test_() ->
   {setup,
    fun setup/0, fun teardown/1,
    [{foreach,
      fun init_stats/0, fun clear_stats/1,
      [?_test(hello_world()),
+      ?_test(scrape()),
       ?_test(sendfile()),
       ?_test(chunked()),
       ?_test(bad_request_line()),
@@ -86,6 +126,30 @@ hello_world() ->
                                       ["full" | Labels])),
   ?assertMatch({1, 12}, summary_value(http_response_body_size_bytes,
                                       ["full" | Labels])).
+
+scrape() ->
+  {ok, Response} = httpc:request("http://localhost:3001/metrics"),
+  ?assertMatch(200, status(Response)),
+  ExpectedCL = integer_to_list(?EMPTY_SCRAPE_SIZE),
+  CT = prometheus_text_format:content_type(),
+  ExpectedCT = binary_to_list(CT),
+  ?assertMatch([{"connection", "Keep-Alive"},
+                {"content-length", ExpectedCL},
+                {"content-type", ExpectedCT}], headers(Response)),
+  ?assertEqual(normalize_text_scrape(?EMPTY_SCRAPE_TEXT),
+               normalize_text_scrape(body(Response))),
+
+  ExpectedSCount = 1,
+
+  ?assertMatch({ExpectedSCount, ?EMPTY_SCRAPE_SIZE},
+               summary_value(telemetry_scrape_size_bytes,
+                             [default, CT])),
+
+  {SCount, SDuration} = summary_value(telemetry_scrape_duration_seconds,
+                                      [default, CT]),
+
+  ?assertMatch(ExpectedSCount, SCount),
+  ?assertEqual(true, SDuration > 0 andalso SDuration < 0.01).
 
 sendfile() ->
   {ok, Response} = httpc:request("http://localhost:3001/sendfile"),
@@ -185,20 +249,20 @@ bad_request_line() ->
   ?assertMatch(1, counter_value(http_requests_failed_total, Labels)).
 
 too_many_headers() ->
-    Headers = lists:duplicate(100, {"X-Foo", "Bar"}),
-    {ok, Response} = httpc:request(get, {"http://localhost:3001/foo", Headers},
-                                   [], []),
+  Headers = lists:duplicate(100, {"X-Foo", "Bar"}),
+  {ok, Response} = httpc:request(get, {"http://localhost:3001/foo", Headers},
+                                 [], []),
   ?assertMatch(400, status(Response)),
 
   ?assertMatch(1, counter_value(http_bad_requests_total, [too_many_headers])),
   ?assertMatch(1, counter_value(http_requests_failed_total, [bad_request])).
 
 way_too_big_body() ->
-    Body = binary:copy(<<"x">>, (1024 * 2000) + 1),
-    ?assertMatch({error, socket_closed_remotely},
-                 httpc:request(post,
-                               {"http://localhost:3001/foo", [], [], Body},
-                               [], [])),
+  Body = binary:copy(<<"x">>, (1024 * 2000) + 1),
+  ?assertMatch({error, socket_closed_remotely},
+               httpc:request(post,
+                             {"http://localhost:3001/foo", [], [], Body},
+                             [], [])),
 
 
   ?assertMatch(1, counter_value(http_bad_requests_total, [body_size])),

--- a/test/elli_prometheus_tests.erl
+++ b/test/elli_prometheus_tests.erl
@@ -1,0 +1,60 @@
+-module(elli_prometheus_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+elli_test_() ->
+  {setup,
+   fun setup/0, fun teardown/1,
+   [{foreach,
+     fun init_stats/0, fun clear_stats/1,
+     [?_test(hello_world())]}]}.
+
+setup() ->
+  application:start(crypto),
+  application:start(public_key),
+  application:start(ssl),
+  inets:start(),
+  prometheus:start(),
+  
+  %% force elli_middleware module loading
+  %% otherwise elli won't recognize it as a callback
+  %% when erlang runs in interactive mode.
+  elli_middleware:module_info(), 
+  Config = [
+            {mods, [
+                    {elli_prometheus, []},
+                    {elli_example_callback, []}
+                   ]}
+           ],
+
+  {ok, P} = elli:start_link([{callback, elli_middleware},
+                             {callback_args, Config},
+                             {port, 3001}]),
+  unlink(P),
+  [P].
+
+teardown(Pids) ->
+  [elli:stop(P) || P <- Pids].
+
+init_stats() ->
+  ets:new(elli_stat_table, [set, named_table, public]).
+
+clear_stats(_) ->
+  ets:delete(elli_stat_table).
+
+hello_world() ->
+  {ok, Response} = httpc:request("http://localhost:3001/hello/world"),
+  ?assertMatch(200, status(Response)),
+  ?assertMatch([{"connection", "Keep-Alive"},
+                {"content-length", "12"}], headers(Response)),
+  ?assertMatch("Hello World!", body(Response)).
+
+%%% Helpers
+
+status({{_, Status, _}, _, _}) ->
+  Status.
+body({_, _, Body}) ->
+  Body.
+
+headers({_, Headers, _}) ->
+  lists:sort(Headers).

--- a/test/elli_prometheus_tests.erl
+++ b/test/elli_prometheus_tests.erl
@@ -15,11 +15,11 @@ setup() ->
   application:start(ssl),
   inets:start(),
   prometheus:start(),
-  
+
   %% force elli_middleware module loading
   %% otherwise elli won't recognize it as a callback
   %% when erlang runs in interactive mode.
-  elli_middleware:module_info(), 
+  elli_middleware:module_info(),
   Config = [
             {mods, [
                     {elli_prometheus, []},
@@ -42,12 +42,47 @@ init_stats() ->
 clear_stats(_) ->
   ets:delete(elli_stat_table).
 
+histogram_count_sum(Name, Labels) ->
+  {Buckets, Sum} = prometheus_histogram:value(Name, Labels),
+  {lists:sum(Buckets), Sum}.
+
+counter_value(Name, Labels) ->
+  prometheus_counter:value(Name, Labels).
+
+summary_value(Name, Labels) ->
+  prometheus_summary:value(Name, Labels).
+
 hello_world() ->
   {ok, Response} = httpc:request("http://localhost:3001/hello/world"),
   ?assertMatch(200, status(Response)),
   ?assertMatch([{"connection", "Keep-Alive"},
                 {"content-length", "12"}], headers(Response)),
-  ?assertMatch("Hello World!", body(Response)).
+  ?assertMatch("Hello World!", body(Response)),
+  %%?debugVal(ets:tab2list(prometheus_histogram_table)),
+  Labels = ['GET', <<"hello">>, "success"],
+  ?assertMatch(1, counter_value(http_requests_total, Labels)),
+  ?assertMatch({1, S} when S > 0,
+                           histogram_count_sum(http_request_duration_microseconds,
+                                               ["full" | Labels])),
+  ?assertMatch({1, S} when S > 0,
+                           histogram_count_sum(http_request_headers_microseconds,
+                                               Labels)),
+  ?assertMatch({1, S} when S > 0,
+                           histogram_count_sum(http_request_body_microseconds,
+                                               Labels)),
+  ?assertMatch({1, S} when S > 0,
+                           histogram_count_sum(http_request_user_microseconds,
+                                               Labels)),
+
+  ?assertMatch({1, S} when S > 0,
+                           histogram_count_sum(http_response_send_microseconds,
+                                               ["full" | Labels])),
+  ?assertMatch({1, 75}, summary_value(http_response_size_bytes,
+                                      ["full" | Labels])),
+  ?assertMatch({1, 63}, summary_value(http_response_headers_size_bytes,
+                                      ["full" | Labels])),
+  ?assertMatch({1, 12}, summary_value(http_response_body_size_bytes,
+                                      ["full" | Labels])).
 
 %%% Helpers
 

--- a/test/elli_prometheus_tests.erl
+++ b/test/elli_prometheus_tests.erl
@@ -241,7 +241,7 @@ bad_request_line() ->
   Req = <<"FOO BAR /hello HTTP/1.1\r\n">>,
   gen_tcp:send(Socket, <<Req/binary, Req/binary>>),
   ?assertMatch({ok, <<"HTTP/1.1 400 Bad Request\r\n"
-                      "Content-Length: 11\r\n\r\n">>},
+                      "Content-Length: 11\r\n\r\nBad Request">>},
                gen_tcp:recv(Socket, 0)),
 
   Labels = [request_parse_error],


### PR DESCRIPTION
**DO NOT MERGE**

Metrics for 'normal' requests
- `http_requests_total`, counter. Total count of requests;
- `http_request_duration_microseconds`, histogram. The difference between
  `request_end` and `request_start`;
- `http_request_headers_microseconds`, histogram. The difference between
  `headers_end` and `headers_start`;
- `http_request_body_microseconds`, histogram. The difference between
  `body_end` and `body_start`;
- `http_request_user_microseconds`, histogram. The difference between
  `user_end` and `user_start`;
- `http_request_send_microseconds`, histogram. The difference between
  `send_end` and `send_start`;
- `http_response_size_bytes`, summary. Total size of the response, includes
  headers, body|file|chuncks;
- `http_response_headers_size_bytes`, summary. Size of the response headers;
- `http_response_body_size`, summary.
  Size of the response body.

Metrics for failed requests (network timeouts, malformed headers, etc)
- `http_requests_failed_total{reason}`, Total count of failed requests. Reasons:
  - `request_closed` - the client closes the connection when Elli is waiting for
    the next request;
  - `request_timeout` - the client times out when Elli is waiting for the request;
  - `request_parse_error` - the request is invalid and cannot be parsed or it
    contains a path Elli cannot parse or doesn't support;
  - `client_closed` - the client closes the connection or socket closed
    unexpectedly;
  - `client_timeout` - data can't be received within a timeout;
  - `bad_request` - Elli detects a request isn't well formatted or doesn't conform
    to the configured limits.
- `http_bad_requests_total{reason}` - Total count of `bad_request` errors.
  Reasons:
  - `too_many_headers`;
  - `body_size`.
- `http_client_closed_total{request_part}` - Total count of `client_closed` errors.
  Parts:
  - `receiving_headers`;
  - `receiving_body`;
  - `before_response`.
- `http_client_timeout_total{request_part}` Total count of `client_timeout` errors.
  Parts:
  - `receiving_headers`;
  - `receiving_body`.
