### PR TITLE
include accept app in applications list

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
-{deps, [{accept, "0.3.0"}]}.
+{deps, [{accept, "0.3.0"},
+        {prometheus, "3.1.0"}]}.
 
 {xref_checks, [undefined_function_calls,locals_not_used]}.
 

--- a/src/elli_prometheus.app.src
+++ b/src/elli_prometheus.app.src
@@ -2,7 +2,7 @@
   {description,  "Elli middleware for collecting stats via Prometheus."},
   {vsn,          "0.1.0"},
   {registered,   []},
-  {applications, [kernel, stdlib, accept]},
+  {applications, [kernel, stdlib, prometheus, accept]},
   {env,          []},
   {modules,      [elli_prometheus]},
 

--- a/src/elli_prometheus.app.src
+++ b/src/elli_prometheus.app.src
@@ -2,7 +2,7 @@
   {description,  "Elli middleware for collecting stats via Prometheus."},
   {vsn,          "0.1.0"},
   {registered,   []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, accept]},
   {env,          []},
   {modules,      [elli_prometheus]},
 


### PR DESCRIPTION
Without this the request will crash, returning a 500 status, unless the user puts `accept` in their projects `.app` file to ensure it is included and loaded in their release.